### PR TITLE
Rework AST for If

### DIFF
--- a/C.flex
+++ b/C.flex
@@ -106,14 +106,14 @@ void count() {
 Ast *Singleton_new(int type) {
     Ast *ans = (Ast *)malloc(sizeof(Ast));
     ans->tag = SINGLETON;
-    ans->type = type;
+    ans->tpe = type;
     return ans;
 }
 
 Ast *TokenString_new(int type, char * lexeme) {
     TokenString *ans = (TokenString *)malloc(sizeof(TokenString));
     ans->ast.tag = TOKEN_STRING;
-    ans->ast.type = type;
+    ans->ast.tpe = type;
     ans->lexeme = lexeme;
     return (Ast *)ans;
 }
@@ -121,7 +121,7 @@ Ast *TokenString_new(int type, char * lexeme) {
 Ast *TokenInt_new(int type, int value) {
     TokenInt *ans = (TokenInt*)malloc(sizeof(TokenInt));
     ans->ast.tag = TOKEN_INT;
-    ans->ast.type = type;
+    ans->ast.tpe = type;
     ans->value = value;
     return (Ast *)ans;
 }

--- a/C.y
+++ b/C.y
@@ -206,7 +206,7 @@ expression_statement
 
 selection_statement
     : IF '(' expression ')' statement                { $$ = BinaryNode_new(IF, $3, $5); }
-    | IF '(' expression ')' statement ELSE statement { $$ = TernaryNode_new(IF, $3, $5, $7); }
+    | IF '(' expression ')' statement ELSE statement { $$ = BinaryNode_new(IF, $3, BinaryNode_new(ELSE, $5, $7)); }
     ;
 
 iteration_statement

--- a/C.y
+++ b/C.y
@@ -206,7 +206,7 @@ expression_statement
 
 selection_statement
     : IF '(' expression ')' statement                { $$ = BinaryNode_new(IF, $3, $5); }
-    | IF '(' expression ')' statement ELSE statement { $$ = BinaryNode_new(IF, $3, BinaryNode_new(ELSE, $5, $7)); }
+    | IF '(' expression ')' statement ELSE statement { $$ = TernaryNode_new(IF, $3, $5, $7); }
     ;
 
 iteration_statement

--- a/ast.c
+++ b/ast.c
@@ -17,6 +17,20 @@ Ast *BinaryNode_new(int t, Ast *a1, Ast *a2) {
   return (Ast*)a;
 }
 
+Ast *TernaryNode_new(int t, Ast *a1, Ast *a2, Ast *a3) {
+  TernaryNode *a = (TernaryNode *)malloc(sizeof(TernaryNode));
+  if (a == NULL) {
+    perror("Cannot make node");
+    exit(1);
+  }
+  a->ast.tag = TERNARY_NODE;
+  a->ast.type = t;
+  a->a1 = a1;
+  a->a2 = a2;
+  a->a3 = a3;
+  return (Ast *)a;
+}
+
 Ast *UnaryNode_new(int t, Ast *a1) {
   UnaryNode *a = (UnaryNode *)malloc(sizeof(UnaryNode));
   if (a == NULL) {

--- a/ast.c
+++ b/ast.c
@@ -4,41 +4,19 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-Ast *BinaryNode_new(int t, Ast *a1, Ast *a2) {
+Ast *UnaryNode_new(int tpe, Ast *a1) {
+  UnaryNode *a = (UnaryNode *)malloc(sizeof(UnaryNode));
+  a->ast.tag = UNARY_NODE;
+  a->ast.tpe = tpe;
+  a->a1 = a1;
+  return (Ast *)a;
+}
+
+Ast *BinaryNode_new(int tpe, Ast *a1, Ast *a2) {
   BinaryNode *a = (BinaryNode *)malloc(sizeof(BinaryNode));
-  if (a == NULL) {
-    perror("Cannot make node");
-    exit(1);
-  }
   a->ast.tag = BINARY_NODE;
-  a->ast.type = t;
+  a->ast.tpe = tpe;
   a->a1 = a1;
   a->a2 = a2;
   return (Ast*)a;
-}
-
-Ast *TernaryNode_new(int t, Ast *a1, Ast *a2, Ast *a3) {
-  TernaryNode *a = (TernaryNode *)malloc(sizeof(TernaryNode));
-  if (a == NULL) {
-    perror("Cannot make node");
-    exit(1);
-  }
-  a->ast.tag = TERNARY_NODE;
-  a->ast.type = t;
-  a->a1 = a1;
-  a->a2 = a2;
-  a->a3 = a3;
-  return (Ast *)a;
-}
-
-Ast *UnaryNode_new(int t, Ast *a1) {
-  UnaryNode *a = (UnaryNode *)malloc(sizeof(UnaryNode));
-  if (a == NULL) {
-    perror("Cannot make node");
-    exit(1);
-  }
-  a->ast.tag = UNARY_NODE;
-  a->ast.type = t;
-  a->a1 = a1;
-  return (Ast *)a;
 }

--- a/ast.h
+++ b/ast.h
@@ -1,7 +1,7 @@
 #ifndef _Ast_H_
 #define _Ast_H_
 
-typedef enum { SINGLETON, UNARY_NODE, BINARY_NODE, TOKEN_INT, TOKEN_STRING } AstTag;
+typedef enum { SINGLETON, UNARY_NODE, BINARY_NODE, TERNARY_NODE, TOKEN_INT, TOKEN_STRING } AstTag;
 
 typedef struct ast {
   AstTag tag;
@@ -19,6 +19,13 @@ typedef struct binary_node {
   Ast *a2;
 } BinaryNode;
 
+typedef struct ternary_node {
+  Ast ast;
+  Ast *a1;
+  Ast *a2;
+  Ast *a3;
+} TernaryNode;
+
 typedef struct token_int {
   Ast ast;
   int value;
@@ -31,6 +38,7 @@ typedef struct token_string {
 
 extern Ast *TokenString_new(int, char*);
 extern Ast *Singleton_new(int);
+Ast *TernaryNode_new(int, Ast *, Ast *, Ast *);
 Ast *BinaryNode_new(int, Ast *, Ast *);
 Ast *UnaryNode_new(int, Ast *);
 

--- a/ast.h
+++ b/ast.h
@@ -1,11 +1,11 @@
 #ifndef _Ast_H_
 #define _Ast_H_
 
-typedef enum { SINGLETON, UNARY_NODE, BINARY_NODE, TERNARY_NODE, TOKEN_INT, TOKEN_STRING } AstTag;
+typedef enum { SINGLETON, UNARY_NODE, BINARY_NODE, TOKEN_INT, TOKEN_STRING } AstTag;
 
 typedef struct ast {
   AstTag tag;
-  int type;
+  int tpe;
 } Ast;
 
 typedef struct unary_node {
@@ -19,13 +19,6 @@ typedef struct binary_node {
   Ast *a2;
 } BinaryNode;
 
-typedef struct ternary_node {
-  Ast ast;
-  Ast *a1;
-  Ast *a2;
-  Ast *a3;
-} TernaryNode;
-
 typedef struct token_int {
   Ast ast;
   int value;
@@ -38,8 +31,7 @@ typedef struct token_string {
 
 extern Ast *TokenString_new(int, char*);
 extern Ast *Singleton_new(int);
-Ast *TernaryNode_new(int, Ast *, Ast *, Ast *);
-Ast *BinaryNode_new(int, Ast *, Ast *);
 Ast *UnaryNode_new(int, Ast *);
+Ast *BinaryNode_new(int, Ast *, Ast *);
 
 #endif

--- a/mmc.c
+++ b/mmc.c
@@ -64,6 +64,7 @@ char *named(Ast *ast) {
 POLYGLOT_DECLARE_STRUCT(ast);
 POLYGLOT_DECLARE_STRUCT(unary_node);
 POLYGLOT_DECLARE_STRUCT(binary_node);
+POLYGLOT_DECLARE_STRUCT(ternary_node);
 POLYGLOT_DECLARE_STRUCT(token_int);
 POLYGLOT_DECLARE_STRUCT(token_string);
 
@@ -72,6 +73,7 @@ POLYGLOT_DECLARE_STRUCT(token_string);
 extern void *get_SymbTable_inst();
 extern void init_SymbTable(void);
 void *ast_to_poly(Ast *ast);
+TernaryNode *ast_to_ternary(Ast *ast);
 
 extern int yydebug;
 extern int yyparse(Ast **);
@@ -90,12 +92,28 @@ void *ast_to_poly(Ast *ast) {
     return polyglot_from_unary_node((UnaryNode *)ast);
   case BINARY_NODE:
     return polyglot_from_binary_node((BinaryNode *)ast);
+  case TERNARY_NODE:
+    return polyglot_from_ternary_node((TernaryNode *)ast);
   case TOKEN_STRING:
     return polyglot_from_token_string((TokenString *)ast);
   case TOKEN_INT:
     return polyglot_from_token_int((TokenInt *)ast);
   case SINGLETON:
     return polyglot_from_ast(ast);
+  }
+}
+
+TernaryNode *ast_to_ternary(Ast *ast) {
+  switch (ast->tag) {
+  case TERNARY_NODE:
+    return (TernaryNode *)ast;
+  case UNARY_NODE:
+  case BINARY_NODE:
+  case TOKEN_STRING:
+  case TOKEN_INT:
+  case SINGLETON:
+    perror("Not ternary");
+    exit(1);
   }
 }
 

--- a/mmc.c
+++ b/mmc.c
@@ -8,7 +8,7 @@
 #include <string.h>
 
 char *named(Ast *ast) {
-  int token = ast->type;
+  int token = ast->tpe;
   static char b[100];
   switch (token) {
   case IDENTIFIER:
@@ -64,7 +64,6 @@ char *named(Ast *ast) {
 POLYGLOT_DECLARE_STRUCT(ast);
 POLYGLOT_DECLARE_STRUCT(unary_node);
 POLYGLOT_DECLARE_STRUCT(binary_node);
-POLYGLOT_DECLARE_STRUCT(ternary_node);
 POLYGLOT_DECLARE_STRUCT(token_int);
 POLYGLOT_DECLARE_STRUCT(token_string);
 
@@ -73,7 +72,6 @@ POLYGLOT_DECLARE_STRUCT(token_string);
 extern void *get_SymbTable_inst();
 extern void init_SymbTable(void);
 void *ast_to_poly(Ast *ast);
-TernaryNode *ast_to_ternary(Ast *ast);
 
 extern int yydebug;
 extern int yyparse(Ast **);
@@ -92,8 +90,6 @@ void *ast_to_poly(Ast *ast) {
     return polyglot_from_unary_node((UnaryNode *)ast);
   case BINARY_NODE:
     return polyglot_from_binary_node((BinaryNode *)ast);
-  case TERNARY_NODE:
-    return polyglot_from_ternary_node((TernaryNode *)ast);
   case TOKEN_STRING:
     return polyglot_from_token_string((TokenString *)ast);
   case TOKEN_INT:
@@ -103,23 +99,9 @@ void *ast_to_poly(Ast *ast) {
   }
 }
 
-TernaryNode *ast_to_ternary(Ast *ast) {
-  switch (ast->tag) {
-  case TERNARY_NODE:
-    return (TernaryNode *)ast;
-  case UNARY_NODE:
-  case BINARY_NODE:
-  case TOKEN_STRING:
-  case TOKEN_INT:
-  case SINGLETON:
-    perror("Not ternary");
-    exit(1);
-  }
-}
-
 AstTag get_tag(Ast *ast) { return ast->tag; }
 
-void *get_type(Ast *ast) { return JAVA_STRING(named(ast)); }
+void *get_tpe(Ast *ast) { return JAVA_STRING(named(ast)); }
 
 void *get_lexeme(TokenString *ast) { return JAVA_STRING(ast->lexeme); }
 

--- a/src/main/scala/mmc/Ast.scala
+++ b/src/main/scala/mmc/Ast.scala
@@ -38,7 +38,7 @@ object Ast {
   case class Assignment(lvalue: Variable, rvalue: Assignments)
   case class Function(id: Scoped, frame: Frame, body: List[Statements])
   case class Block(inner: List[Statements])
-  case class IfElse(id: Long, test: Expressions, ifThen: List[Statements], orElse: Option[List[Statements]])
+  case class IfElse(id: Long, test: Expressions, ifThen: List[Statements], orElse: List[Statements])
 
   def temporaryAssignment(value: Assignments): Assignment =
     Assignment(new Temporary, value)

--- a/src/main/scala/mmc/Parser.scala
+++ b/src/main/scala/mmc/Parser.scala
@@ -23,7 +23,7 @@ import exception._
   mmclib.setDebug(debug)
   mmclib.initSymbTable()
 
-  for t <- mmclib.getAst do try {
+  for t <- mmclib.parse() do try {
     timeIt("LEXING_TIME")
     val identPool = mmclib.identPool
     timeIt("EXPORT_IDENTIFIERS")

--- a/src/main/scala/mmc/astToNormal.scala
+++ b/src/main/scala/mmc/astToNormal.scala
@@ -10,71 +10,68 @@ object astToNormal extends Stage {
   type Context = parseCAst.Context
   type Goal    = parseCAst.Goal
 
-  private type FlattenO[T, O] = PartialFunction[T, O]
-  private type FlattenL[T, O] = FlattenO[T, List[O]]
-  private type Flatten[T] = FlattenL[T, T]
+  private type Flatten[T] = T =?> List[T]
   private type Stack = List[Assignment]
 
   def apply(context: Context, source: Source): (Context, Goal) =
     mainDefined(context) { _ -> declarationsList(source) }
 
-  private def identity[A]: PartialFunction[A, A] = {
+  private def identity[A]: A =?> A = {
     case x => x
   }
 
-  private lazy val declarationsList: FlattenO[Source, Goal] =
-    identity >>- declarations
+  private lazy val declarationsList: Source =?> Goal
+    = identity >>- declarations
 
-  private lazy val declarations: Flatten[Declarations] =
-    function .L |
-    declaration .L |
-    assignments
+  private lazy val declarations: Flatten[Declarations]
+    = function .L
+    | declaration .L
+    | assignments
 
-  private lazy val assignments: FlattenO[Statements, Stack] =
-    assignmentsImpl .R
+  private lazy val assignments: Statements =?> Stack
+    = assignmentsImpl .R
 
-  private lazy val assignmentsImpl: FlattenO[Statements, Stack] =
-    assignmentsWithEffects |
-    literals .E
+  private lazy val assignmentsImpl: Statements =?> Stack
+    = assignmentsWithEffects
+    | literals .E
 
-  private lazy val tryReduce: FlattenO[Assignments, Stack] =
-    assignmentsWithEffects |
-    (literals ->> temporaryAssignment) .L
+  private lazy val tryReduce: Assignments =?> Stack
+    = assignmentsWithEffects
+    | (literals ->> temporaryAssignment) .L
 
-  private lazy val jumpStatements: Flatten[Statements] =
-    jumpStatementsImpl .R
+  private lazy val jumpStatements: Flatten[Statements]
+    = jumpStatementsImpl .R
 
-  private lazy val selectionStatements: Flatten[Statements] =
-    selectionStatementsImpl .R
+  private lazy val selectionStatements: Flatten[Statements]
+    = selectionStatementsImpl .R
 
-  private lazy val arg: FlattenO[Assignments, Assignments] =
-    node |
-    ex
+  private lazy val arg: Assignments =?> Assignments
+    = node
+    | ex
 
-  private lazy val ex: FlattenO[Assignments, Primary] =
-    literals |
-    assignment ->> { _.lvalue }
+  private lazy val ex: Assignments =?> Primary
+    = literals
+    | assignment ->> { _.lvalue }
 
-  private lazy val statementList: FlattenO[List[Statements], List[Statements]] =
-    identity >>- statements
+  private lazy val statementList: List[Statements] =?> List[Statements]
+    = identity >>- statements
 
-  private lazy val expressions: FlattenO[Expressions, Stack] =
-    expressionsImpl .R
+  private lazy val expressions: Expressions =?> Stack
+    = expressionsImpl .R
 
-  private lazy val expressionsImpl: FlattenO[Expressions, Stack] =
-    identity >>- (tryReduce .R)
+  private lazy val expressionsImpl: Expressions =?> Stack
+    = identity >>- (tryReduce .R)
 
-  private lazy val statements: Flatten[Statements] =
-    block .L |
-    function .L |
-    declaration .L |
-    assignments |
-    jumpStatements |
-    selectionStatements
+  private lazy val statements: Flatten[Statements]
+    = block .L
+    | function .L
+    | declaration .L
+    | assignments
+    | jumpStatements
+    | selectionStatements
 
-  private val function: FlattenO[Statements, Function] = {
-    case Function(i, f, body) =>
-      Function(i, f, eliminateTemporaries(statementList(body)))
+  private val function: Statements =?> Function = {
+    case Function(i, f, body) => Function(i, f, eliminateTemporaries(statementList(body)))
   }
 
   private def eliminateTemporaries(statements: List[Statements]): List[Statements] = {
@@ -100,11 +97,11 @@ object astToNormal extends Stage {
     acc
   }
 
-  private val declaration: FlattenO[Statements, Declaration] = {
+  private val declaration: Statements =?> Declaration = {
     case d: Declaration => d
   }
 
-  private val block: FlattenO[Statements, Block] = {
+  private val block: Statements =?> Block = {
     case Block(v) => Block(statementList(v))
   }
 
@@ -112,44 +109,32 @@ object astToNormal extends Stage {
     case Return(v) => foldArguments(v) { mapReturn }
   }
 
-  private def mapReturn
-    ( args: Expressions,
-      stack: Stack
-    ): List[Statements] =
-      (args.lastOption, stack) match {
-        case (Some(a), _) =>
-          Return(a :: Nil) :: stack
-        case _ =>
-          Return(Nil) :: stack
-      }
+  private def mapReturn(args: Expressions, stack: Stack): List[Statements] =
+    args.lastOption match {
+      case Some(a) => Return(a :: Nil) :: stack
+      case _       => Return(Nil)      :: stack
+    }
 
   private val selectionStatementsImpl: Flatten[Statements] = {
-    case IfElse(ic, test, ifThen, orElse) => foldArguments(test) {
-      mapIfElse(ic, ifThen, orElse)
-    }
+    case IfElse(ic, test, ifThen, orElse) => foldArguments(test)(mapIfElse(ic, ifThen, orElse))
   }
 
-  private def mapIfElse
-    ( ifCount: Long,
-      ifThen: List[Statements],
-      orElse: Option[List[Statements]] )
-    ( args: Expressions,
-      stack: Stack
-    ): List[Statements] =
-      (args.lastOption, stack) match {
-        case (Some(a), _) =>
-          val ifThenMapped = statementList(ifThen)
-          val elseMapped = orElse.map(statementList).filter(!_.isEmpty)
-          if elseMapped.isEmpty && ifThenMapped.isEmpty then {
-            stack
-          } else {
-            IfElse(ifCount, a :: Nil, ifThenMapped, elseMapped) :: stack
-          }
-        case _ =>
-          throw UnexpectedAstNode("Empty If statement test")
-      }
+  private def mapIfElse(ifCount: Long, ifThen: List[Statements], orElse: List[Statements])(
+      args: Expressions, stack: Stack): List[Statements] =
+    args.lastOption match {
+      case Some(a) =>
+        val ifThenMapped = statementList(ifThen)
+        val elseMapped   = statementList(orElse)
+        if elseMapped.isEmpty && ifThenMapped.isEmpty then {
+          stack
+        } else {
+          IfElse(ifCount, a :: Nil, ifThenMapped, elseMapped) :: stack
+        }
 
-  private val assignmentsWithEffects: FlattenO[Statements, Stack] = {
+      case _ => throw UnexpectedAstNode("Empty If statement test")
+    }
+
+  private val assignmentsWithEffects: Statements =?> Stack = {
     case Assignment(d, v) => assignment(d, v)
     case Equality(op, l, r) => binary(Equality, op, l, r)
     case Relational(op, l, r) => binary(Relational, op, l, r)
@@ -161,18 +146,16 @@ object astToNormal extends Stage {
   }
 
   private def application(p: Postfix, e: Expressions): Stack = p match {
-      case a: Application =>
-        applicationA(a, e)
-      case i: Scoped =>
-        applicationP(i, e)
-      case LazyExpressions(l)
-        if l.lastOption.forall(canApply) =>
-          applicationE(l, e)
-      case _ =>
-        throw SemanticError("Application of non function type")
-    }
+    case a: Application => applicationA(a, e)
+    case i: Scoped      => applicationP(i, e)
 
-  private val canApply: FlattenO[Assignments, Boolean] = {
+    case LazyExpressions(l)
+      if l.lastOption.forall(canApply) => applicationE(l, e)
+
+    case _ => throw SemanticError("Application of non function type")
+  }
+
+  private val canApply: Assignments =?> Boolean = {
     case _: (Application | Identifier) => true
     case _ => false
   }
@@ -182,112 +165,71 @@ object astToNormal extends Stage {
   }
 
   private def applicationE(lazyExpressions: Expressions, args: Expressions): Stack = {
-    foldArguments(lazyExpressions) { (e, stack) =>
-      applicationP(ex(e.last), args) ++ stack
-    }
+    foldArguments(lazyExpressions)((e, stack) => applicationP(ex(e.last), args) ::: stack)
   }
 
   private def applicationP(p: Primary, e: Expressions): Stack =
-    foldArgumentsNT(e) { Application(p, _) }
+    foldArgumentsNT(e)(Application(p, _))
 
   private def assignment(dest: Variable, v: Assignments): Stack =
-    foldArguments(List(v)) { mapAssignment(dest) }
+    foldArguments(List(v))(mapAssignment(dest))
 
-  private def mapAssignment
-    ( dest: Variable )
-    ( args: Expressions,
-      stack: Stack
-    ): Stack =
-      (args, stack) match {
-        case (Assignment(_: Temporary, t) :: _, _ :: (rest: Stack)) =>
-          Assignment(dest, t) :: rest
-        case (a :: _, _) =>
-          Assignment(dest, a) :: stack
-        case _ =>
-          stack
-      }
+  private def mapAssignment(dest: Variable)(args: Expressions, stack: Stack): Stack = args -> stack match {
+    case (Assignment(_: Temporary, t) :: _) -> (_ :: rest: Stack) => Assignment(dest, t) :: rest
+    case (a :: _) -> _                                            => Assignment(dest, a) :: stack
+    case _                                                        => stack
+  }
 
-  private def unary[Op <: UnaryOp, A >: Primary]
-    ( f: (Op, A) => Assignments,
-      o: Op, v: Assignments
-    ): Stack =
-      foldArgumentsNT(List(v)) { mapUnary(f, o) }
+  private def unary[Op <: UnaryOp, A >: Primary](f: (Op, A) => Assignments, o: Op, v: Assignments): Stack =
+    foldArgumentsNT(List(v))(mapUnary(f, o))
 
-  private def binary[Op <: BinaryOp, A >: Primary, B >: Primary]
-    ( f: (Op, A, B) => Assignments,
-      o: Op,
-      l: Assignments,
-      r: Assignments
-    ): Stack =
-      foldArgumentsNT(List(l, r)) { mapBinary(f, o) }
+  private def binary[Op <: BinaryOp, A >: Primary, B >: Primary](f: (Op, A, B) => Assignments, o: Op, l: Assignments,
+      r: Assignments): Stack =
+    foldArgumentsNT(List(l, r))(mapBinary(f, o))
 
-  private def foldArgumentsN
-    ( e: Expressions )
-    ( f: Expressions => Assignment
-    ): Stack =
-      foldArguments(e) { f(_) :: _ }
+  private def foldArgumentsN(e: Expressions)(f: Expressions => Assignment): Stack =
+    foldArguments(e)(f(_)::_)
 
-  private def foldArgumentsNT
-    ( e: Expressions )
-    ( f: Expressions => Assignments
-    ): Stack =
-      foldArgumentsN(e) { temporaryAssignment.compose(f) }
+  private def foldArgumentsNT(e: Expressions)(f: Expressions => Assignments): Stack =
+    foldArgumentsN(e)(temporaryAssignment.compose(f))
 
-  private def mapUnary[Op <: UnaryOp, A >: Primary, O >: Assignments]
-    ( f: (Op, A) => O,
-      o: Op
-    ): PartialFunction[Expressions, O] = {
-      case Constant(a: IntLiteral) :: _ =>
-        Constant(IntLiteral(o.op(a.value)))
-      case a :: _ =>
-        f(o, a.asInstanceOf[A])
-    }
+  private def mapUnary[Op <: UnaryOp, A >: Primary, O >: Assignments](f: (Op, A) => O, o: Op): Expressions =?> O = {
+    case Constant(a: IntLiteral) :: _ => Constant(IntLiteral(o.op(a.value)))
+    case a :: _                       => f(o, a.asInstanceOf[A])
+  }
 
-  private def mapBinary[Op <: BinaryOp, A >: Primary, B >: Primary]
-    ( f: (Op, A, B) => Assignments,
-      o: Op
-    ): PartialFunction[Expressions, Assignments] = {
-      case Constant(a: IntLiteral) :: Constant(b: IntLiteral) :: _ =>
-        Constant(IntLiteral(o.op(a.value, b.value)))
-      case a :: b :: _ =>
-        f(o, a.asInstanceOf[A], b.asInstanceOf[B])
-    }
+  private def mapBinary[Op <: BinaryOp, A >: Primary, B >: Primary](f: (Op, A, B) => Assignments, o: Op)
+    : Expressions =?> Assignments = {
+    case Constant(a: IntLiteral) :: Constant(b: IntLiteral) :: _ => Constant(IntLiteral(o.op(a.value, b.value)))
+    case a :: b :: _                                             => f(o, a.asInstanceOf[A], b.asInstanceOf[B])
+  }
 
 
-  private def foldArguments[A]
-    ( ex: Expressions )
-    ( fn: (Expressions, Stack) => A
-    ): A = {
-      val (args, repush, stack) =
-        ex.map(tryReduce)
-          .foldLeft(Nil, Nil, Nil) { mapArguments }
-      fn(args, repush ++ stack)
-    }
+  private def foldArguments[A](ex: Expressions)(fn: (Expressions, Stack) => A): A = {
+    val (args, repush, stack) = ex.map(tryReduce).foldLeft(Nil, Nil, Nil)(mapArguments)
+    fn(args, repush ::: stack)
+  }
 
   private type StackAcc = (Expressions, Stack, Stack)
 
-  private def mapArguments(acc: StackAcc, argStack: Stack): StackAcc =
-    acc match {
-      case (args, repush, stack) =>
-        argStack match {
-          case Assignment(_: Temporary, c: Literals) :: (rest: Stack) =>
-            (args :+ c, repush, rest ++ stack)
-          case s :: (rest: Stack) =>
-            (args :+ arg(s), s :: repush, rest ++ stack)
-          case Nil =>
-            acc
-        }
+  private def mapArguments(acc: StackAcc, argStack: Stack): StackAcc = {
+    val (args, repush, stack) = acc
+    argStack match {
+      case Assignment(_: Temporary, c: Literals) :: (rest: Stack) => (args :+ c, repush, rest ::: stack)
+      case s :: (rest: Stack)                                     => (args :+ arg(s), s :: repush, rest ::: stack)
+      case Nil                                                    => acc
     }
+  }
 
-  private val assignment: FlattenO[Assignments, Assignment] = {
+  private val assignment: Assignments =?> Assignment = {
     case a: Assignment => a
   }
 
-  private val literals: FlattenO[Statements, Primary] = {
+  private val literals: Statements =?> Primary = {
     case c: Literals => c
   }
 
-  private val node: FlattenO[Statements, Assignments] = {
+  private val node: Statements =?> Assignments = {
     case n: Node => n
   }
 }

--- a/src/main/scala/mmc/normalToInterpreter.scala
+++ b/src/main/scala/mmc/normalToInterpreter.scala
@@ -8,12 +8,12 @@ object normalToInterpreter extends Stage {
   type Goal    = astToNormal.Goal
 
   def apply(context: Context, nodes: Source): (Context, Goal) =
-    context -> nodes.foldRight(Nil: Goal) { topLevelStatement(_) ++ _ }
+    context -> nodes.foldRight(Nil: Goal) { topLevelStatement(_) ::: _ }
 
   private def topLevelStatement(node: Declarations): Goal = node match {
     case Function(Std.`mainIdentifier`, f, body) =>
       val validated = body.foldRight(Nil: List[Statements]) {
-        evalStatement(_) ++ _
+        evalStatement(_) ::: _
       }
       List(Function(Std.mainIdentifier, f, validated))
     case a: Assignment => List(a)

--- a/src/main/scala/mmc/package.scala
+++ b/src/main/scala/mmc/package.scala
@@ -6,6 +6,8 @@ import ArgList._
 
 given as Conversion[Boolean, Int] = if _ then 1 else 0
 
+type =?>[I,O] = PartialFunction[I,O]
+
 case object ScopeKey extends Bindings.Key {
   type Value = Long
 }

--- a/src/main/scala/mmc/parseCAst.scala
+++ b/src/main/scala/mmc/parseCAst.scala
@@ -162,7 +162,7 @@ class parseCAst private
     | expressionsStatement
     | jumpStatement
     | selections .L
-    | { case value => throw UnimplementedError(s"statement: $value") }
+    | { case value => throw UnimplementedError(s"statement (${value.ast.tpe}):\n${value.printAst}") }
 
   private def makeIf
     (test: Source, ifThen: Source): IfElse = {

--- a/src/main/scala/mmc/parseCAst.scala
+++ b/src/main/scala/mmc/parseCAst.scala
@@ -168,7 +168,7 @@ class parseCAst private
   private lazy val selections: Parse[IfElse] = ifElse
 
   private val ifElse: Parse[Selections] = {
-    case TernaryNode("if", test, ifThen, orElse) =>
+    case BinaryNode("if", test, BinaryNode("else", ifThen, orElse)) =>
       makeIfElse(test, inlineBlock(ifThen), inlineBlock(orElse))
     case BinaryNode("if", test, ifThen) =>
       makeIfElse(test, inlineBlock(ifThen), None)

--- a/src/main/scala/mmc/printAst.scala
+++ b/src/main/scala/mmc/printAst.scala
@@ -14,75 +14,66 @@ object printAst {
   def apply(nodes: List[Declarations]): Unit =
     print(astNode(nodes, 0))
 
-  private def astNode
-    ( nodes: List[Statements],
-      level: Int
-    ): String =
-      (for node <- nodes yield astNode(node, level)).mkString
+  private def astNode(nodes: List[Statements], level: Int): String =
+    nodes.map(astNode(_, level)).mkString
 
-  private def astNode
-    ( node: Statements,
-      level: Int
-    ): String = {
-      def getIt(value: Statements): String = astNode(value, level);
-      def exp(value: Assignments): String = expr(value, level);
-      var lvl = getLevel(level)
-      node match {
-        case Declaration(storage, types, declarator) =>
-          declarator match {
-            case Scoped(id,_) =>
-              s"$lvl${storageToString(storage)}${typesToString(types)} $id;$endl"
-            case FunctionDeclarator(Scoped(id,_), args) =>
-              s"$lvl${storageToString(storage)}${typesToString(types)} $id${getArgList(args)};$endl"
-          }
-        case Assignment(Scoped(id,_), value) =>
-          s"$lvl$id = ${exp(value)};$endl"
-        case Assignment(t: Temporary, value) =>
-          s"$lvl${showTemporary(t)} = ${exp(value)};$endl"
-        case Function(i @ Scoped(id,_), _, b) =>
-          fn(id, b, level)
-        case Block(b) => block(b, level)
-        case Return(Nil) => s"${lvl}return;$endl"
-        case Return(v) =>
-          val newArgs = v.map(exp).mkString(", ")
-          s"${lvl}return $newArgs;$endl"
-        case IfElse(_, test, ifThen, orElse) =>
-          ifElse(test,ifThen,orElse,level)
-        case _ => s"${lvl}???$endl"
-      }
+  private def astNode(node: Statements, level: Int): String = {
+    def getIt(value: Statements): String = astNode(value, level);
+    def exp(value: Assignments): String = expr(value, level);
+    var lvl = getLevel(level)
+    node match {
+      case Declaration(storage, types, declarator) =>
+        declarator match {
+          case Scoped(id,_) =>
+            s"$lvl${storageToString(storage)}${typesToString(types)} $id;$endl"
+          case FunctionDeclarator(Scoped(id,_), args) =>
+            s"$lvl${storageToString(storage)}${typesToString(types)} $id${getArgList(args)};$endl"
+        }
+      case Assignment(Scoped(id,_), value) =>
+        s"$lvl$id = ${exp(value)};$endl"
+      case Assignment(t: Temporary, value) =>
+        s"$lvl${showTemporary(t)} = ${exp(value)};$endl"
+      case Function(i @ Scoped(id,_), _, b) =>
+        fn(id, b, level)
+      case Block(b) => block(b, level)
+      case Return(Nil) => s"${lvl}return;$endl"
+      case Return(v) =>
+        val newArgs = v.map(exp).mkString(", ")
+        s"${lvl}return $newArgs;$endl"
+      case IfElse(_, test, ifThen, orElse) =>
+        ifElse(test,ifThen,orElse,level)
+      case _ => s"${lvl}???$endl"
     }
+  }
 
-  private def expr
-    ( node: Assignments,
-      level: Int
-    ): String = {
-      def getIt(value: Assignments): String = expr(value, level)
-      node match {
-        case Application(i, args) =>
-          val newArgs = args.map(getIt).mkString(", ")
-          s"${getIt(i)}($newArgs)"
-        case Equality(op, l, r) =>
-          getBinary(op, getIt(l), getIt(r))
-        case Relational(op, l, r) =>
-          getBinary(op, getIt(l), getIt(r))
-        case Additive(op, l, r) =>
-          getBinary(op, getIt(l), getIt(r))
-        case Multiplicative(op, l, r) =>
-          getBinary(op, getIt(l), getIt(r))
-        case Unary(op, v) =>
-          getUnary(op, getIt(v))
-        case Constant(str: StringLiteral) =>
-          s""""$str""""
-        case Constant(v) =>
-          s"$v"
-        case Scoped(i,_) =>
-          s"$i"
-        case t: Temporary =>
-          showTemporary(t)
-        case x =>
-          throw UnexpectedAstNode(s"expression: ${x.toString}")
-      }
+  private def expr(node: Assignments, level: Int): String = {
+    def getIt(value: Assignments): String = expr(value, level)
+    node match {
+      case Application(i, args) =>
+        val newArgs = args.map(getIt).mkString(", ")
+        s"${getIt(i)}($newArgs)"
+      case Equality(op, l, r) =>
+        getBinary(op, getIt(l), getIt(r))
+      case Relational(op, l, r) =>
+        getBinary(op, getIt(l), getIt(r))
+      case Additive(op, l, r) =>
+        getBinary(op, getIt(l), getIt(r))
+      case Multiplicative(op, l, r) =>
+        getBinary(op, getIt(l), getIt(r))
+      case Unary(op, v) =>
+        getUnary(op, getIt(v))
+      case Constant(str: StringLiteral) =>
+        s""""$str""""
+      case Constant(v) =>
+        s"$v"
+      case Scoped(i,_) =>
+        s"$i"
+      case t: Temporary =>
+        showTemporary(t)
+      case x =>
+        throw UnexpectedAstNode(s"expression: ${x.toString}")
     }
+  }
 
   private def getUnary(op: Operand, v: String): String =
     s"${op.symbol} $v"
@@ -99,52 +90,34 @@ object printAst {
     }).mkString("(", ", ", ")")
   }
 
-  private def fn
-    ( name: String,
-      b: List[Statements],
-      level: Int
-    ): String = {
-      var lvl: String = getLevel(level)
-      var res = s"$lvl$name: {$endl"
-      if !b.isEmpty then
-        res + astNode(b, inc(level)) + s"$lvl}$endl"
-      else
-        res + s"}$endl"
-    }
+  private def fn(name: String, b: List[Statements], level: Int): String = {
+    var lvl: String = getLevel(level)
+    var res = s"$lvl$name: {$endl"
+    if !b.isEmpty then
+      res + astNode(b, inc(level)) + s"$lvl}$endl"
+    else
+      res + s"}$endl"
+  }
 
-  private def block
-    ( b: List[Statements],
-      level: Int
-    ): String = {
-      var lvl: String = getLevel(level)
-      if b.isEmpty then
-        s"$lvl{}$endl"
-      else
-        s"$lvl{$endl${astNode(b, inc(level))}$lvl}$endl"
-    }
+  private def block(b: List[Statements], level: Int): String = {
+    var lvl: String = getLevel(level)
+    if b.isEmpty then
+      s"$lvl{}$endl"
+    else
+      s"$lvl{$endl${astNode(b, inc(level))}$lvl}$endl"
+  }
 
-  private def ifElse
-    ( test: Expressions,
-      ifThen: List[Statements],
-      orElse: Option[List[Statements]],
-      level: Int
-    ): String = {
-      var lvl: String = getLevel(level)
-      val testStr = test.map(expr(_,level)).mkString(", ")
-      val ifThenStr = astNode(ifThen, inc(level))
-      if orElse.isEmpty then
-        s"${lvl}if ($testStr) {$endl$ifThenStr$lvl}$endl"
-      else {
-        val orElseG = orElse.get
-        if orElseG.isEmpty then {
-          s"${lvl}if ($testStr) {$endl$ifThenStr$lvl} else {$endl$lvl}$endl"
-        } else {
-          val orElseStr = astNode(orElseG, inc(level))
-          s"${lvl}if ($testStr) {$endl$ifThenStr$lvl} else {$endl$orElseStr$lvl}$endl"
-        }
-      }
-
+  private def ifElse(test: Expressions, ifThen: List[Statements], orElse: List[Statements], level: Int): String = {
+    var lvl: String = getLevel(level)
+    val testStr = test.map(expr(_,level)).mkString(", ")
+    val ifThenStr = astNode(ifThen, inc(level))
+    if orElse.isEmpty then
+      s"${lvl}if ($testStr) {$endl$ifThenStr$lvl}$endl"
+    else {
+      val orElseStr = astNode(orElse, inc(level))
+      s"${lvl}if ($testStr) {$endl$ifThenStr$lvl} else {$endl$orElseStr$lvl}$endl"
     }
+  }
 
   private def inc(level: Int) = level + 2
 

--- a/testfile
+++ b/testfile
@@ -1,7 +1,12 @@
 int main(void) {
     int a, b;
-    a = read_int();
-    b = read_int();
+    {{}}
+    {
+        {
+            a = read_int();
+            b = read_int();
+        }
+    }
     if (a < b) {
         if (a > 0) {
             print_int(a * b);

--- a/testfile
+++ b/testfile
@@ -13,5 +13,8 @@ int main(void) {
     } else {
         print_int(a % b);
     }
+    while (a < 200) {
+        a = read_int();
+    }
     return 0;
 }

--- a/testfile
+++ b/testfile
@@ -13,8 +13,5 @@ int main(void) {
     } else {
         print_int(a % b);
     }
-    while (a < 200) {
-        a = read_int();
-    }
     return 0;
 }


### PR DESCRIPTION
- ~~Introduce `TernaryNode` in `ast.c`~~ [removed due to issue below]
  - ~~This has a weird interaction with GraalVM and requires an explicit cast to make the `a3` member visible, which is not necessary for `a2` in `BinaryNode`.~~
- Vastly simplify the cases for if in `parseCAst`.
- Make else part of `If` a `List[Statements]`, not `Option[List[Statements]]`
- Refactor the syntax to be more regular with established Scala styles
- Erase a block if it is empty or inline the contents if it only contains a single nested block.
- `printAst` now builds a string, rather than output to console.