### PR TITLE
upgrade to Dotty 0.19.0-RC1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ LLVM_LINK = ${LLVM_HOME}/llvm-link
 TARGET = src/main/resources/mmclib
 
 SCALA_LIB_VERSION = 2.13.0
-DOTTY_VERSION     = 0.18
-DOTTY_MINOR       = 1
+DOTTY_VERSION     = 0.19
+DOTTY_MINOR       = 0
 DOTTY_SUFFIX      = RC1
 JAR = target/scala-${DOTTY_VERSION}/mmc_${DOTTY_VERSION}-0.1.0.jar
 TAIL = ${DOTTY_VERSION}.${DOTTY_MINOR}-${DOTTY_SUFFIX}

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val dottyVersion = "0.18.1-RC1"
+val dottyVersion = "0.19.0-RC1"
 // val dottyVersion = dottyLatestNightlyBuild.get
 val graalvmVersion = "19.2.0"
 

--- a/mmc.c
+++ b/mmc.c
@@ -69,6 +69,8 @@ POLYGLOT_DECLARE_STRUCT(token_string);
 
 #define JAVA_STRING(expr) polyglot_from_string(expr, "UTF-8")
 
+static Ast *null_Ast = NULL;
+
 extern void *get_SymbTable_inst();
 extern void init_SymbTable(void);
 void *ast_to_poly(Ast *ast);
@@ -99,12 +101,16 @@ void *ast_to_poly(Ast *ast) {
   }
 }
 
-AstTag get_tag(Ast *ast) { return ast->tag; }
+AstTag Ast_tag(Ast *ast) { return ast->tag; }
 
-void *get_tpe(Ast *ast) { return JAVA_STRING(named(ast)); }
+void *Ast_tpe(Ast *ast) { return JAVA_STRING(named(ast)); }
 
-void *get_lexeme(TokenString *ast) { return JAVA_STRING(ast->lexeme); }
+Ast *UnaryNode_a1(UnaryNode *ast) { return ast->a1; }
 
-int get_value(TokenInt *ast) { return ast->value; }
+Ast *BinaryNode_a2(BinaryNode *ast) { return ast->a2; }
+
+void *TokenString_lexeme(TokenString *ast) { return JAVA_STRING(ast->lexeme); }
+
+int TokenInt_value(TokenInt *ast) { return ast->value; }
 
 void free_pointer(void *any) { free(any); }

--- a/src/main/scala/mmc/mmclib.scala
+++ b/src/main/scala/mmc/mmclib.scala
@@ -1,5 +1,8 @@
 package mmc
 
+import scala.annotation.switch
+import scala.collection.mutable
+
 import java.io._
 
 import org.graalvm.polyglot._
@@ -11,15 +14,15 @@ import org.graalvm.polyglot._
  */
 object mmclib { self =>
   import opaques._
-  import AstTag._
-  import given CAst._
-  import given AstInfo._
+  import CAst.given
+  import AstInfo.{given, _}
 
   private val polyglot = Context.newBuilder().allowAllAccess(true).build
   private val source   = Source.newBuilder("llvm", getClass.getResource("/mmclib")).build
   private val mmclib   = polyglot.eval(source)
 
   private object opaques {
+
     opaque type CAst    = Value
     opaque type AstInfo = Value
 
@@ -27,6 +30,7 @@ object mmclib { self =>
 
     object CAst {
       given (node: CAst) {
+
         def ast: AstInfo =
           if node.hasMember("ast") then
             node.getMember("ast")
@@ -39,33 +43,47 @@ object mmclib { self =>
     }
 
     object AstInfo {
+
+      type AstTag = Singleton | UnaryNode | BinaryNode | TokenInt | TokenString
+
+      private val AstTags = mutable.ArrayBuffer.empty[AstTag]
+      private def enter[T <: AstTag](tag: T): Unit = { AstTags += tag }
+
+      // Keep in sync with ast.h `AstTag`
+      final class Singleton   private[AstInfo](); enter(Singleton())
+      final class UnaryNode   private[AstInfo](); enter(UnaryNode())
+      final class BinaryNode  private[AstInfo](); enter(BinaryNode())
+      final class TokenInt    private[AstInfo](); enter(TokenInt())
+      final class TokenString private[AstInfo](); enter(TokenString())
+
+      AstTags.trimToSize()
+
       given (node: AstInfo) {
-        def tpe: String = get_tpe(node).asString
-        def tag: AstTag = AstTags(get_tag(node).asInt)
+        def tpe: String = Ast_tpe(node).asString
+        def tag: AstTag = AstTags(Ast_tag(node).asInt)
       }
+
     }
 
-    def (node: CAst) a1     : CAst   = ast_to_poly(node.getMember("a1"))
-    def (node: CAst) a2     : CAst   = ast_to_poly(node.getMember("a2"))
-    def (node: CAst) lexeme : String = get_lexeme(node).asString
-    def (node: CAst) value  : Int    = get_value(node).asInt
+    def (node: CAst) a1 (given UnaryNode | BinaryNode): CAst = UnaryNode_a1(node)
+    def (node: CAst) a2 (given BinaryNode): CAst = BinaryNode_a2(node)
+    def (node: CAst) lexeme (given TokenString): String = TokenString_lexeme(node).asString
+    def (node: CAst) value (given TokenInt): Int = TokenInt_value(node).asInt
+
+    val EmptyAst: CAst = null_Ast
 
     def free(node: CAst): Unit = free_pointer.executeVoid(node)
   }
 
-  export opaques.{CAst, AstInfo, parse, free}
-
-  enum AstTag { case SINGLETON, UNARY_NODE, BINARY_NODE, TOKEN_INT, TOKEN_STRING }
-
-  private val AstTags = AstTag.values.sortWith(_.ordinal < _.ordinal)
+  export opaques.{CAst, AstInfo, EmptyAst, parse, free}
 
   object BinaryNode {
     def unapply(node: CAst): Option[(String, CAst, CAst)] = {
       val ast = node.ast
       val tpe = ast.tpe
       ast.tag match {
-        case BINARY_NODE if !sequenceTpes.contains(tpe) => Some((tpe, node.a1, node.a2))
-        case _                                          => None
+        case given _: BinaryNode if !sequenceTpes.contains(tpe) => Some((tpe, node.a1, node.a2))
+        case _                                                  => None
       }
     }
   }
@@ -74,8 +92,8 @@ object mmclib { self =>
     def unapply(node: CAst): Option[(String, CAst)] = {
       val ast = node.ast
       ast.tag match {
-        case UNARY_NODE => Some((ast.tpe, node.a1))
-        case _          => None
+        case given _: UnaryNode => Some((ast.tpe, node.a1))
+        case _                  => None
       }
     }
   }
@@ -84,8 +102,8 @@ object mmclib { self =>
     def unapply(node: CAst): Option[String] = {
       val ast = node.ast
       ast.tag match {
-        case SINGLETON => Some(ast.tpe)
-        case _         => None
+        case _: Singleton => Some(ast.tpe)
+        case _            => None
       }
     }
   }
@@ -94,8 +112,8 @@ object mmclib { self =>
     def unapply(node: CAst): Option[(String, Int)] = {
       val ast = node.ast
       ast.tag match {
-        case TOKEN_INT => Some((ast.tpe, node.value))
-        case _         => None
+        case given _: TokenInt => Some((ast.tpe, node.value))
+        case _                 => None
       }
     }
   }
@@ -104,8 +122,8 @@ object mmclib { self =>
     def unapply(node: CAst): Option[(String, String)] = {
       val ast = node.ast
       ast.tag match {
-        case TOKEN_STRING => Some((ast.tpe, node.lexeme))
-        case _            => None
+        case given _: TokenString => Some((ast.tpe, node.lexeme))
+        case _                    => None
       }
     }
   }
@@ -115,42 +133,45 @@ object mmclib { self =>
       val ast = node.ast
       val tpe = ast.tpe
       ast.tag match {
-        case BINARY_NODE if sequenceTpes.contains(tpe) => Some((tpe, node.sequence(tpe)))
-        case _                                         => None
+        case given _: BinaryNode if sequenceTpes.contains(tpe) => Some((tpe, sequence(tpe, node.a1, node.a2)))
+        case _                                                 => None
       }
     }
   }
 
   private val sequenceTpes = Set("E", ";", ",", "~")
 
-  private def (node: CAst) sequence(tpe: String): List[CAst] = {
-    var current = node
-    var list = List.empty[CAst]
+  private def sequence(tpe: String, a1: CAst, a2: CAst): List[CAst] = {
+    var left    = a1
+    var right   = a2
+    var list    = List.empty[CAst]
     var reverse = false
     var decided = false
-    var left  = current.a1
-    var right = current.a2
-    var break = false
+    var break   = false
     while (!break) {
       val leftinfo = left.ast
       val rightinfo = right.ast
-      if (leftinfo.tag == BINARY_NODE && leftinfo.tpe == tpe) {
+      if (leftinfo.tag.isInstanceOf[BinaryNode] && leftinfo.tpe == tpe) {
         if (!decided) {
           decided = true;
         }
-        list  = right :: list
-        current  = left
-        left  = current.a1
-        right = current.a2
-      } else if (rightinfo.tag == BINARY_NODE && rightinfo.tpe == tpe) {
+        list = right :: list
+        (left.ast.tag: @unchecked) match {
+          case given _: BinaryNode =>
+            right = left.a2
+            left  = left.a1
+        }
+      } else if (rightinfo.tag.isInstanceOf[BinaryNode] && rightinfo.tpe == tpe) {
         if (!decided) {
           decided = true
           reverse = true
         }
         list  = left :: list
-        current  = right
-        left  = current.a1
-        right = current.a2
+        (right.ast.tag: @unchecked) match {
+          case given _: BinaryNode =>
+            left  = right.a1
+            right = right.a2
+        }
       } else {
         if (reverse) {
           list = right :: left :: list
@@ -185,33 +206,28 @@ object mmclib { self =>
       printLevel(level, builder)
       val ast = node.ast
       ast.tag match {
-        case UNARY_NODE =>
-          printUnaryNode(node, level, builder)
-        case BINARY_NODE =>
-          printBinaryNode(node, level, builder)
-        case TOKEN_STRING =>
-          printTokenString(node, builder)
-        case TOKEN_INT =>
-          printTokenInt(node, builder)
-        case SINGLETON =>
-          printSingleton(ast, builder)
+        case given _: UnaryNode   => node.printUnaryNode(level, builder)
+        case given _: BinaryNode  => node.printBinaryNode(level, builder)
+        case given _: TokenString => node.printTokenString(builder)
+        case given _: TokenInt    => node.printTokenInt(builder)
+        case given _: Singleton   => ast.printSingleton(builder)
       }
     } else {
       builder
     }
 
-  private def printUnaryNode(node: CAst, level: Int, builder: StringBuilder): StringBuilder = {
+  private def (node: CAst) printUnaryNode(level: Int, builder: StringBuilder)(given UnaryNode): StringBuilder = {
     builder.addAll(s"${node.ast.tpe}\n")
     printAst0(node.a1, level + 2, builder)
   }
 
-  private def printBinaryNode(node: CAst, level: Int, builder: StringBuilder): StringBuilder = {
+  private def (node: CAst) printBinaryNode(level: Int, builder: StringBuilder)(given BinaryNode): StringBuilder = {
     builder.addAll(s"${node.ast.tpe}\n")
     printAst0(node.a1, level + 2, builder)
     printAst0(node.a2, level + 2, builder)
   }
 
-  private def printTokenString(node: CAst, builder: StringBuilder): StringBuilder = {
+  private def (node: CAst) printTokenString(builder: StringBuilder)(given TokenString): StringBuilder = {
     val info = node.ast
     info.tpe match {
       case "string" =>
@@ -221,19 +237,21 @@ object mmclib { self =>
     }
   }
 
-  private def printTokenInt(node: CAst, builder: StringBuilder): StringBuilder = builder.addAll(s"${node.value}\n")
+  private def (node: CAst) printTokenInt(builder: StringBuilder)(given TokenInt): StringBuilder = builder.addAll(s"${node.value}\n")
 
-  private def printSingleton(ast: AstInfo, builder: StringBuilder): StringBuilder = builder.addAll(s"${ast.tpe}\n")
+  private def (ast: AstInfo) printSingleton(builder: StringBuilder)(given Singleton): StringBuilder = builder.addAll(s"${ast.tpe}\n")
 
   private def printLevel(level: Int, builder: StringBuilder): StringBuilder = builder.addAll(" " * level)
 
   private inline def (f: Value) apply(args: AnyRef*): Value = f.execute(args: _*)
 
-  private val get_tag = mmclib.getMember("get_tag")
-  private val get_tpe = mmclib.getMember("get_tpe")
-  private val get_value = mmclib.getMember("get_value")
-  private val get_lexeme = mmclib.getMember("get_lexeme")
-  private val ast_to_poly = mmclib.getMember("ast_to_poly")
+  private val null_Ast = mmclib.getMember("null_Ast")
+  private val Ast_tag = mmclib.getMember("Ast_tag")
+  private val Ast_tpe = mmclib.getMember("Ast_tpe")
+  private val UnaryNode_a1 = mmclib.getMember("UnaryNode_a1")
+  private val BinaryNode_a2 = mmclib.getMember("BinaryNode_a2")
+  private val TokenInt_value = mmclib.getMember("TokenInt_value")
+  private val TokenString_lexeme = mmclib.getMember("TokenString_lexeme")
   private val free_pointer = mmclib.getMember("free_pointer")
   private val set_debug = mmclib.getMember("set_debug")
   private val get_ast = mmclib.getMember("get_ast")

--- a/src/main/scala/mmc/package.scala
+++ b/src/main/scala/mmc/package.scala
@@ -4,7 +4,7 @@ import Constants._
 import exception._
 import ArgList._
 
-given as Conversion[Boolean, Int] = if _ then 1 else 0
+given Conversion[Boolean, Int] = if _ then 1 else 0
 
 type =?>[I,O] = PartialFunction[I,O]
 

--- a/testfile
+++ b/testfile
@@ -1,12 +1,7 @@
 int main(void) {
     int a, b;
-    {{}}
-    {
-        {
-            a = read_int();
-            b = read_int();
-        }
-    }
+    a = read_int();
+    b = read_int();
     if (a < b) {
         if (a > 0) {
             print_int(a * b);


### PR DESCRIPTION
This also experiments with adding safer accessors for `CAst`
- Require `given` evidence for calling `a1`, `a2` etc. that can be only obtained from the `tag` method.
- However this still does not prevent abuse of passing the given evidence to call an accessor on the wrong value, still need to ensure that accessors are only called on the correct value
- As a result, the accessors still can't leak `mmclib`