### PR TITLE
Refactor and Fix missing statements bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ mips:
 	${PARSER} -m > out.asm
 
 run:
-	${PARSER} -i
+	${PARSER} -i -int
 
 pkg: ${TARGET}
 	sbt package

--- a/src/main/scala/mmc/Ast.scala
+++ b/src/main/scala/mmc/Ast.scala
@@ -7,7 +7,7 @@ object Ast
   type Selections             = IfElse
   type Statements             = Block | Declarations | Assignments | Return | Selections
   type InitDeclarator         = Declarator | Assignment
-  type DeclarationSpecifiers  = Type | Storage
+  type DeclarationSpecifiers  = TypeRef | Storage
   type Declarations           = Declaration | Function | Assignment
   type Expressions            = List[Assignments]
   type Literals               = Scoped | Constant
@@ -25,8 +25,8 @@ object Ast
                                   Unary | Constant | Variable
 
   case class Constant(value: StringLiteral | IntLiteral)
-  case class Type(id: Types)
-  case class Storage(id: StorageTypes)
+  case class TypeRef(id: Type)
+  case class Storage(id: StorageKind)
   case class Return(value: Expressions)
   case class Application(operand: Postfix, args: Expressions)
   case class LazyExpressions(value: Expressions)
@@ -42,4 +42,3 @@ object Ast
 
   def temporaryAssignment(value: Assignments): Assignment =
     Assignment(new Temporary, value)
-

--- a/src/main/scala/mmc/Core.scala
+++ b/src/main/scala/mmc/Core.scala
@@ -1,6 +1,6 @@
 package mmc
 
-import language.implicitConversions
+import scala.language.implicitConversions
 
 type Parameter  = (Type, Scoped) | Type
 type Variable   = Scoped | Temporary

--- a/src/main/scala/mmc/Core.scala
+++ b/src/main/scala/mmc/Core.scala
@@ -2,7 +2,7 @@ package mmc
 
 import language.implicitConversions
 
-type Parameter  = (Types, Scoped) | Types
+type Parameter  = (Type, Scoped) | Type
 type Variable   = Scoped | Temporary
 type Declarator = Scoped | FunctionDeclarator
 type Identifier = String
@@ -11,9 +11,9 @@ class Temporary
 case class Scoped(id: Identifier, scope: Long)
 case class FunctionDeclarator(id: Scoped, args: ArgList)
 
-case class Declaration(storage: StorageTypes, declType: Types, declarator: Declarator)
+case class Declaration(storage: StorageKind, declType: Type, declarator: Declarator)
 
-enum ArgList
+enum ArgList derives Eql
   case LVoid
   case LAny
   case LParam(list: List[Parameter])
@@ -25,18 +25,16 @@ object Constants
   def IntLiteral(i: Int): IntLiteral = i
   def StringLiteral(s: String): StringLiteral = s
 
-  object IntLiteral
-    given :(c: IntLiteral)
-      def  value: Int = c
+  given (c: IntLiteral)
+    def value: Int = c
 
-  object StringLiteral
-    given : (s: StringLiteral)
-      def value: String = s
+  given (s: StringLiteral)
+    def value: String = s
 
-enum Types
+enum Type derives Eql
   case Cint, Cvoid, Cfunction, Cstring
 
-enum StorageTypes
+enum StorageKind derives Eql
   case Auto, Extern
 
 trait Operand(val symbol: String)
@@ -71,8 +69,8 @@ enum UnaryOperators(op: Int => Int, symbol: String) extends Operand(symbol) with
 
 object Std
   import ArgList._
-  import StorageTypes._
-  import Types._
+  import StorageKind._
+  import Type._
 
   val mainIdentifier    = Scoped("main",0)
   val mainIdentifierKey = DeclarationKey(Std.mainIdentifier.id)

--- a/src/main/scala/mmc/DSL.scala
+++ b/src/main/scala/mmc/DSL.scala
@@ -1,7 +1,6 @@
 package mmc
 
 import mmclib.{_, given}
-import AstTag._
 
 object DSL
 
@@ -40,14 +39,14 @@ object DSL
     while !break do
       val leftinfo = left.ast
       val rightinfo = right.ast
-      if leftinfo.tag == BinaryNode && leftinfo.tpe == tpe then
+      if leftinfo.tag.isBinary && leftinfo.tpe == tpe then
         if !decided then
           decided = true;
         list = right :: list
         left.binaryOp:
           left  = binary.a1
           right = binary.a2
-      else if rightinfo.tag == BinaryNode && rightinfo.tpe == tpe then
+      else if rightinfo.tag.isBinary && rightinfo.tpe == tpe then
         if !decided then
           decided = true
           reverse = true

--- a/src/main/scala/mmc/Parser.scala
+++ b/src/main/scala/mmc/Parser.scala
@@ -15,47 +15,88 @@ import exception._
   var old           = System.currentTimeMillis
   var newtime       = 0L
 
-  if doTime then println("START: 0ms")
+  if doTime then info("START: 0ms")
 
-  mmclib // force it to load
-
-  timeIt("GRAAL_CONTEXT_STARTUP")
+  initmmclib()
 
   mmclib.setDebug(debug)
   mmclib.initSymbTable()
 
-  for nativeAst <- mmclib.parse() do try
-    timeIt("LEXING_TIME")
-    val identifiers = timed("EXPORT_IDENTIFIERS"):
-      guard(mmclib.identifiers): // TODO -- concurrent: - partition indent pool by job id
-        mmclib.clearIdentPool()
-    printStage(name = "PRINT_AST", label = "AST", guard = doPrintAst):
-      println(DSL.show(nativeAst))
-    val (context, ast) = timed("PARSE_CAST"):
-      parseCAst(nativeAst, identifiers) // TODO -- reentrant: - free nativeAst
-    val (nContext, astFlattened) = timed("AST_TO_NORMAL"):
-      astToNormal(context, ast)
-    printStage(name = "PRINTING_CODE", label = "NORMAL", guard = doPrintNormal):
-      printAst(astFlattened)
+  for nativeAst <- parseNativeAst() do try
+    val identifiers = exportIdentifiers()
+    printNativeAst(nativeAst)
+    val (context, ast) = astFromNative(nativeAst, identifiers)
+    val (nContext, normalAst) = aNormalForm(context, ast)
+    printNormalAst(normalAst)
     if doInterpret then
-      val (intContext, intCode) = timed("FILTER_NORMAL_TO_INTERPRETER"):
-        normalToInterpreter(nContext, astFlattened)
-      printStage(name = "PRINTING_NORMAL_FOR_INTERPRETER", label = "NORMAL_FILTERED", guard = doPrintInt):
-        printAst(intCode)
-      timed("INTERPRETING_NORMAL"):
-        interpretAst(intContext, intCode)
+      val interpreterAst = interpreterCode(normalAst)
+      printInterpreterAst(interpreterAst)
+      interpret(nContext, interpreterAst)
     else
-      val (tacContext, tac) = timed("NORMAL_TO_TAC"):
-        normalToTac(astFlattened)
-      printStage(name = "PRINTING_TAC", label = "TAC", guard = doPrintTac):
-        printTac(tacContext,tac)
-      val mips = timed("TAC_TO_MIPS"):
-        tacToMips(tacContext, tac)
-      printStage(name = "PRINT_MIPS", label = "MIPS", guard = doPrintMips):
-        printMips(mips)
+      val (tacContext, tac) = tacCode(normalAst)
+      printTacCode(tacContext, tac)
+      printMipsCode(mipsCode(tacContext, tac))
   catch
     case e: (SemanticError | UnexpectedAstNode | UnimplementedError) =>
       Console.err.println(s"[ERROR] $e")
+
+  def initmmclib() =
+    timed("GRAAL_CONTEXT_STARTUP"):
+      mmclib // force it to load
+      ()
+
+  def parseNativeAst() =
+    timed("PARSE_TEXT"):
+      mmclib.parse()
+
+  def astFromNative(nativeAst: mmclib.CAst, identifiers: Set[Identifier]) =
+    timed("NATIVE_AST_TO_SCALA"):
+      parseCAst(nativeAst, identifiers) // TODO -- reentrant: - free nativeAst
+
+  def exportIdentifiers() =
+    timed("EXPORT_IDENTIFIERS"):
+      guard(mmclib.identifiers): // TODO -- concurrent: - partition indent pool by job id
+        mmclib.clearIdentPool()
+
+  def aNormalForm(context: parseCAst.Context, ast: parseCAst.Goal) =
+    timed("AST_TO_NORMAL"):
+      astToNormal(context, ast)
+
+  def interpreterCode(normalAst: astToNormal.Goal) =
+    timed("FILTER_NORMAL_TO_INTERPRETER"):
+      normalToInterpreter(normalAst)
+
+  def mipsCode(tacContext: normalToTac.Context, tac: normalToTac.Goal) =
+    timed("TAC_TO_MIPS"):
+      tacToMips(tacContext, tac)
+
+  def interpret(interpreterContext: normalToInterpreter.Context, interpreterAst: normalToInterpreter.Goal) =
+    timed("INTERPRETING_NORMAL"):
+      interpretAst(interpreterContext, interpreterAst)
+
+  def tacCode(normalAst: astToNormal.Goal) =
+    timed("NORMAL_TO_TAC"):
+      normalToTac(normalAst)
+
+  def printNativeAst(nativeAst: mmclib.CAst) =
+    printStage(name = "PRINT_AST", label = "AST", guard = doPrintAst):
+      println(DSL.show(nativeAst))
+
+  def printNormalAst(normalAst: astToNormal.Goal) =
+    printStage(name = "PRINTING_CODE", label = "NORMAL", guard = doPrintNormal):
+      printAst(normalAst)
+
+  def printInterpreterAst(interpreterAst: normalToInterpreter.Goal) =
+    printStage(name = "PRINTING_NORMAL_FOR_INTERPRETER", label = "NORMAL_FILTERED", guard = doPrintInt):
+        printAst(interpreterAst)
+
+  def printTacCode(tacContext: normalToTac.Context, tac: normalToTac.Goal) =
+    printStage(name = "PRINTING_TAC", label = "TAC", guard = doPrintTac):
+      printTac(tacContext, tac)
+
+  def printMipsCode(mips: tacToMips.Goal) =
+    printStage(name = "PRINT_MIPS", label = "MIPS", guard = doPrintMips):
+      printMips(mips)
 
   inline def timed[A](label: String)(op: => A): A = guard(op)(timeIt(label))
 
@@ -63,12 +104,14 @@ import exception._
 
   def printStage(name: String, label: String, guard: Boolean)(op: => Unit): Unit =
     if guard then
-      if doSeparate then println(label + ":")
+      if doSeparate then info(label + ":")
       op
       timeIt(name)
 
   def timeIt(label: String): Unit =
     if doTime then
       newtime = System.currentTimeMillis
-      println(s"$label: ${newtime - old}ms")
+      info(s"$label: ${newtime - old}ms")
       old = newtime
+
+  def info(msg: String) = println("[INFO] " + msg)

--- a/src/main/scala/mmc/Parser.scala
+++ b/src/main/scala/mmc/Parser.scala
@@ -4,10 +4,11 @@ import exception._
 
 @main def Parser(args: String*) =
   val debug         = args.contains("-debug")
-  val doPrint       = args.contains("-p")
+  val doPrintAst    = args.contains("-p")
   val doTime        = args.contains("-time")
   val doInterpret   = args.contains("-i")
   val doPrintNormal = args.contains("-n")
+  val doPrintInt    = args.contains("-int")
   val doPrintMips   = args.contains("-m")
   val doPrintTac    = args.contains("-t")
   val doSeparate    = args.contains("-sep")
@@ -23,48 +24,48 @@ import exception._
   mmclib.setDebug(debug)
   mmclib.initSymbTable()
 
-  for t <- mmclib.parse() do try
+  for nativeAst <- mmclib.parse() do try
     timeIt("LEXING_TIME")
-    val identPool = mmclib.identPool
-    timeIt("EXPORT_IDENTIFIERS")
-    val cast = t
-    if doPrint then
-      println("AST:")
-      DSL.show(t)
-      timeIt("PRINT_AST")
-    val (context, ast) = parseCAst(cast, identPool) // TODO: Re-entrant - free memory
-    timeIt("PARSE_CAST")
-    val (nContext, astFlattened) = astToNormal(context, ast)
-    timeIt("AST_TO_NORMAL")
-    if doPrintNormal then
-      if doSeparate then println("NORMAL:")
+    val identifiers = timed("EXPORT_IDENTIFIERS"):
+      guard(mmclib.identifiers): // TODO -- concurrent: - partition indent pool by job id
+        mmclib.clearIdentPool()
+    printStage(name = "PRINT_AST", label = "AST", guard = doPrintAst):
+      println(DSL.show(nativeAst))
+    val (context, ast) = timed("PARSE_CAST"):
+      parseCAst(nativeAst, identifiers) // TODO -- reentrant: - free nativeAst
+    val (nContext, astFlattened) = timed("AST_TO_NORMAL"):
+      astToNormal(context, ast)
+    printStage(name = "PRINTING_CODE", label = "NORMAL", guard = doPrintNormal):
       printAst(astFlattened)
-      timeIt("PRINTING_CODE")
     if doInterpret then
-      val (intContext, intCode) =
+      val (intContext, intCode) = timed("FILTER_NORMAL_TO_INTERPRETER"):
         normalToInterpreter(nContext, astFlattened)
-      timeIt("FILTER_NORMAL_TO_INTERPRETER")
-      if doSeparate then println("NORMAL_FILTERED:")
-      printAst(intCode)
-      timeIt("PRINTING_NORMAL_FOR_INTERPRETER")
-      interpretAst(intContext, intCode)
-      timeIt("INTERPRETING_NORMAL")
+      printStage(name = "PRINTING_NORMAL_FOR_INTERPRETER", label = "NORMAL_FILTERED", guard = doPrintInt):
+        printAst(intCode)
+      timed("INTERPRETING_NORMAL"):
+        interpretAst(intContext, intCode)
     else
-      val (tContext2, tac2) = normalToTac(astFlattened)
-      timeIt("NORMAL_TO_TAC")
-      if doPrintTac then
-        if doSeparate then println("TAC:")
-        printTac(tContext2,tac2)
-        timeIt("PRINTING_TAC")
-      val mips2 = tacToMips(tContext2, tac2)
-      timeIt("TAC_TO_MIPS")
-      if doPrintMips then
-        if doSeparate then println("MIPS:")
-        printMips(mips2)
-        timeIt("PRINT_MIPS")
+      val (tacContext, tac) = timed("NORMAL_TO_TAC"):
+        normalToTac(astFlattened)
+      printStage(name = "PRINTING_TAC", label = "TAC", guard = doPrintTac):
+        printTac(tacContext,tac)
+      val mips = timed("TAC_TO_MIPS"):
+        tacToMips(tacContext, tac)
+      printStage(name = "PRINT_MIPS", label = "MIPS", guard = doPrintMips):
+        printMips(mips)
   catch
     case e: (SemanticError | UnexpectedAstNode | UnimplementedError) =>
       Console.err.println(s"[ERROR] $e")
+
+  inline def timed[A](label: String)(op: => A): A = guard(op)(timeIt(label))
+
+  inline def guard[A](op: => A)(guard: => Unit): A = { val a = op; guard; a }
+
+  def printStage(name: String, label: String, guard: Boolean)(op: => Unit): Unit =
+    if guard then
+      if doSeparate then println(label + ":")
+      op
+      timeIt(name)
 
   def timeIt(label: String): Unit =
     if doTime then

--- a/src/main/scala/mmc/normalToInterpreter.scala
+++ b/src/main/scala/mmc/normalToInterpreter.scala
@@ -7,8 +7,8 @@ object normalToInterpreter extends Stage
   type Context = astToNormal.Context
   type Goal    = astToNormal.Goal
 
-  def apply(context: Context, nodes: Source): (Context, Goal) =
-    context -> nodes.foldRight(List.empty[Declarations])(topLevelStatement(_) ::: _)
+  def apply(nodes: Source): Goal =
+    nodes.foldRight(List.empty[Declarations])(topLevelStatement(_) ::: _)
 
   private def topLevelStatement(node: Declarations): Goal = node match
     case Function(Std.`mainIdentifier`, f, body) =>

--- a/src/main/scala/mmc/package.scala
+++ b/src/main/scala/mmc/package.scala
@@ -61,7 +61,7 @@ def showVariable(lvalue: Variable): String = lvalue match
   case t: Temporary => showTemporary(t)
 
 def showTemporary(temporary: Temporary): String =
-  ("@" + temporary.hashCode).take(6)
+  ("@" + Integer.toHexString(temporary.hashCode)).take(6)
 
 def getCurrentScope(bindings: Bindings): Long =
   bindings.genGet(ScopeKey).getOrElse:

--- a/src/main/scala/mmc/printAst.scala
+++ b/src/main/scala/mmc/printAst.scala
@@ -2,8 +2,8 @@ package mmc
 
 import Ast._
 import Constants._
-import StorageTypes._
-import Types._
+import StorageKind._
+import Type._
 import ArgList._
 import exception._
 
@@ -61,8 +61,8 @@ object printAst
   private def getArgList(a: ArgList): String = a match
     case LParam(params) =>
       params.map {
-        case t: Types => typesToString(t)
-        case (t: Types, Scoped(i,_)) => s"${typesToString(t)} $i"
+        case t: Type => typesToString(t)
+        case (t: Type, Scoped(i,_)) => s"${typesToString(t)} $i"
       } mkString("(", ", ", ")")
 
     case LVoid => "(void)"
@@ -95,11 +95,11 @@ object printAst
 
   private def inc(level: Int) = level + 2
 
-  private def storageToString(s: StorageTypes) = s match
+  private def storageToString(s: StorageKind) = s match
     case Auto => ""
     case _    => s"$s "
 
-  private def typesToString(s: Types) = s match
+  private def typesToString(s: Type) = s match
     case Cint       => "int"
     case Cvoid      => "void"
     case Cfunction  => "function"

--- a/src/main/scala/mmc/printTac.scala
+++ b/src/main/scala/mmc/printTac.scala
@@ -7,7 +7,7 @@ import TwoControlOperators._
 import OneControlOperators._
 import exception._
 import Constants._
-import Types._
+import Type._
 
 object printTac
 
@@ -107,7 +107,7 @@ object printTac
   private def labels(v: LabelIds): String =
     s"${evalLabels(v)}:$endl"
 
-  private def evalType(types: Types): String = types match
+  private def evalType(types: Type): String = types match
     case Cint => "%I32"
     case Cfunction => "%Function"
     case Cvoid => "%Void"


### PR DESCRIPTION
- refactor main method
- `normalToTac` ignored statements with `Constant(IntLiteral(foo))` - they were expecting an ast node to be `IntLiteral` - type safety has been lost by using opaque types here